### PR TITLE
Add an instruction for chocolatey users

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,17 @@ $ brew cask install font-hackgen
 $ brew cask install font-hackgen-nerd
 ```
 
+### Chocolatey によるフォントのインストール
+
+Windows の [Chocolatey](https://chocolatey.org/) ユーザーは以下のコマンドでもインストールすることができます。  
+[font-hackgen](https://chocolatey.org/packages/font-hackgen) が Nerd Fonts を含まないフォント、[font-hackgen-nerd](https://chocolatey.org/packages/font-hackgen-nerd) が Nerd Fonts を含むフォントです。  
+※インストールに失敗する場合は、[パッケージのリポジトリ](https://github.com/kai2nenobu/chocolatey-packages/)にissueを投稿してください。
+
+```
+> choco install font-hackgen
+> choco install font-hackgen-nerd
+```
+
 ## ビルド環境
 
 HackGen は以下の環境でビルドしています。


### PR DESCRIPTION
## 変更内容

[Chocolatey](https://chocolatey.org/)のパッケージを作成しましたので、Chocolateyユーザー向けのインストールコマンドをREADMEに追加しました。[font-hackgen](https://chocolatey.org/packages/font-hackgen)がNerd Fontsを含まないフォントのパッケージ、[font-hackgen-nerd](https://chocolatey.org/packages/font-hackgen-nerd)がNerd Fontsを含むフォントのパッケージになります。

パッケージの本体は[私のリポジトリ](https://github.com/kai2nenobu/chocolatey-packages/)にありますので、そちらへの誘導も含めました。万一このリポジトリのissueなどにChocolateyパッケージに関する問い合わせなどがあれば、そちらに誘導していただければと思います。

## パッケージのアップデートについて

このリポジトリのReleasesを定期的にチェックしており、HackGenがアップデートされたらパッケージも自動でアップデートするようになっています。（Chocolatey側で人手のレビューが入るので、数日のラグはあると思います）

ただし、Releasesのzipのファイル命名規則が変わったり、zipの中のフォントが増えたりすると自動アップデートで対応できない可能性が高いです。そのような変更が入る場合は事前に教えてもらえるとありがたいです。

