### PR TITLE
左右クオテーションマークでサイズが異なる

### DIFF
--- a/hackgen_generator.sh
+++ b/hackgen_generator.sh
@@ -1305,10 +1305,12 @@ while (i < SizeOf(input_list))
   Select(0uff5b); Move(-bracket_move, 0); SetWidth(${hackgen_full_width}) # {
   Select(0uff5d); Move( bracket_move, 0); SetWidth(${hackgen_full_width}) # }
 
-  # 全角 ，．’” の調整
+  # 全角 ，．‘’“” の調整
   Select(0uff0e);Scale(155) ; SetWidth(${hackgen_full_width}) # ．
   Select(0uff0c);Scale(145) ; SetWidth(${hackgen_full_width}) # ，
+  Select(0u2018);Scale(145) ; SetWidth(${hackgen_full_width}) # ‘
   Select(0u2019);Scale(145) ; SetWidth(${hackgen_full_width}) # ’
+  Select(0u201c);Scale(145) ; SetWidth(${hackgen_full_width}) # “
   Select(0u201d);Scale(145) ; SetWidth(${hackgen_full_width}) # ”
 
   # 下限で見切れているグリフの調整
@@ -1486,10 +1488,12 @@ while (i < SizeOf(input_list))
   Select(0uff5b); Move(-bracket_move, 0); SetWidth(${hackgen35_full_width}) # {
   Select(0uff5d); Move( bracket_move, 0); SetWidth(${hackgen35_full_width}) # }
 
-  # 全角 ，．’” の調整
+  # 全角 ，．‘’“” の調整
   Select(0uff0e);Scale(155) ; SetWidth(${hackgen35_full_width}) # ．
   Select(0uff0c);Scale(145) ; SetWidth(${hackgen35_full_width}) # ，
+  Select(0u2018);Scale(145) ; SetWidth(${hackgen35_full_width}) # ‘
   Select(0u2019);Scale(145) ; SetWidth(${hackgen35_full_width}) # ’
+  Select(0u201c);Scale(145) ; SetWidth(${hackgen35_full_width}) # “
   Select(0u201d);Scale(145) ; SetWidth(${hackgen35_full_width}) # ”
 
   # Save modified GenJyuuGothicL


### PR DESCRIPTION
先日[告知](https://twitter.com/tawara_san/status/1372046628731817986)されていらしたように，v2.3.1 で全角の約物のサイズを調整していただいたようなのですが，この調整の結果，下図のように左右でクオテーションマークのサイズがアンバランスになってしまったようです．

![Screen Shot 2021-03-24 at 15 36 21](https://user-images.githubusercontent.com/9448125/112268370-340cec80-8cba-11eb-942b-cbd69c8e5e9e.png)

（スクショは macOS 11.2.3, CotEditor, HackGenNerd Regular で撮影）

現状，生成スクリプトでは右側のクオテーション，すなわち

* U+2019 RIGHT SINGLE QUOTATION MARK
* U+201D RIGHT DOUBLE QUOTATION MARK

のみをサイズ調整の対象とされているようですが

* U+2018 LEFT SINGLE QUOTATION MARK
* U+201C LEFT DOUBLE QUOTATION MARK

も加えてみるのはどうでしょうか．

一応，この変更を入れて手元でフォント生成をしたところ，左右のバランスが取れるようです．ビルド済みの ttf もありますが，ビルド環境の差異による変化が生じてしまうと嫌なので，このプルリクエストには含めていません．