### PR TITLE
Homebrew installation update

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Mac の Homebrew ユーザーは以下のコマンドでもインストールす
 
 ```
 $ brew tap homebrew/cask-fonts
-$ brew cask install font-hackgen
-$ brew cask install font-hackgen-nerd
+$ brew install font-hackgen
+$ brew install font-hackgen-nerd
 ```
 
 ### Chocolatey によるフォントのインストール


### PR DESCRIPTION
The usage of Homebrew Cask has [changed a bit](https://github.com/Homebrew/homebrew-cask/blob/master/USAGE.md#installing-casks), and it seems that an error occurs if "cask" is present. It is now better to either remove it (`$ brew install <PACKAGE_NAME>`) or to add the `--cask` option strictly, as in `$ brew install --cask <PACKAGE_NAME>`. The former is sufficient in this case, so I suggest fixing it that way.
Thank you for the nice font!