### PR TITLE
fix: remove deprecated tap command

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ Mac の Homebrew ユーザーは以下のコマンドでもインストールす
 ※Homebrew リポジトリに追加してくださったのはユーザーさんなので、使用方法などをリポジトリオーナーはサポートできません。悪しからずご了承ください。
 
 ```
-$ brew tap homebrew/cask-fonts
 $ brew install font-hackgen
 $ brew install font-hackgen-nerd
 ```


### PR DESCRIPTION
fontのcaskをtapする必要がなくなったので、削除しました。
```
brew tap homebrew/cask-fonts
==> Auto-updating Homebrew...
Adjust how often this is run with HOMEBREW_AUTO_UPDATE_SECS or disable with
HOMEBREW_NO_AUTO_UPDATE. Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
==> Auto-updated Homebrew!
Updated 2 taps (ngrok/ngrok and homebrew/cask).
==> New Casks
dockdoor                                         ivacy                                            longplay

You have 36 outdated formulae and 4 outdated casks installed.

Error: homebrew/cask-fonts was deprecated. This tap is now empty and all its contents were either deleted or migrated.
```