### PR TITLE
Lint scripts.

### DIFF
--- a/cmap_patch.sh
+++ b/cmap_patch.sh
@@ -15,7 +15,7 @@ function buildCmap() {
   ttx_path="$1"
   # cmapマスタの作成
   (
-    awk 'NR > 1 {print}' "$CMAP_MASTER" | while read line
+    awk 'NR > 1 {print}' "$CMAP_MASTER" | while read -r line
     do
       out_name=$(echo "$line" | awk -F, '{print $4}')
       grep_out_name=$(grep -E -m1 "name=\"${out_name}[#\"]" "$ttx_path" | perl -pe 's/^.+name="([^"]+?)".+/$1/')
@@ -38,7 +38,7 @@ function buildCmap() {
     grep -E -v 'cmap_format_14| uvs=' "$ttx_path" | awk '/<\/cmap>/ {exit} {print}'
     cat "$TMP_TTX"
     awk 'BEGIN {prFlag = 0} /<post>/ {prFlag = 1} prFlag == 1 {print}' "$ttx_path"
-  ) > $GENERATED_CMAP
+  ) > "$GENERATED_CMAP"
 }
 
 function proc() {
@@ -49,10 +49,10 @@ function proc() {
     return
   fi
 
-  ttx -t cmap -t post $font
-  mv ${font} ${font}_orig
+  ttx -t cmap -t post "$font"
+  mv "${font}" "${font}_orig"
   buildCmap "${font%%.ttf}.ttx"
-  ttx -o ${font} -m ${font}_orig $GENERATED_CMAP
+  ttx -o "${font}" -m "${font}_orig" "$GENERATED_CMAP"
 }
 
 echo '### Start cmap_patch ###'
@@ -83,4 +83,4 @@ for f in $font_list; do
   rm "$output_filename"
 done
 
-rm -f "$GENERATED_CMAP"_* "$TMP_CMAP_MASTER"_* "$TMP_TTX"_* *.ttx *.ttf_orig
+rm -f "$GENERATED_CMAP"_* "$TMP_CMAP_MASTER"_* "$TMP_TTX"_* ./*.ttx ./*.ttf_orig

--- a/cmap_patch.sh
+++ b/cmap_patch.sh
@@ -18,7 +18,7 @@ function buildCmap() {
     awk 'NR > 1 {print}' "$CMAP_MASTER" | while read line
     do
       out_name=$(echo "$line" | awk -F, '{print $4}')
-      grep_out_name=$(egrep -m1 "name=\"${out_name}[#\"]" "$ttx_path" | perl -pe 's/^.+name="([^"]+?)".+/$1/')
+      grep_out_name=$(grep -E -m1 "name=\"${out_name}[#\"]" "$ttx_path" | perl -pe 's/^.+name="([^"]+?)".+/$1/')
       if [ -z "$grep_out_name" ]; then
         continue
       fi
@@ -35,7 +35,7 @@ function buildCmap() {
 
   # 適用するttxファイルを作成
   (
-    egrep -v 'cmap_format_14| uvs=' "$ttx_path" | awk '/<\/cmap>/ {exit} {print}'
+    grep -E -v 'cmap_format_14| uvs=' "$ttx_path" | awk '/<\/cmap>/ {exit} {print}'
     cat "$TMP_TTX"
     awk 'BEGIN {prFlag = 0} /<post>/ {prFlag = 1} prFlag == 1 {print}' "$ttx_path"
   ) > $GENERATED_CMAP

--- a/cmap_patch.sh
+++ b/cmap_patch.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 BASE_DIR=$(cd "$(dirname "$0")" && pwd)
 PREFIX="$1"
 

--- a/cmap_patch.sh
+++ b/cmap_patch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-BASE_DIR=$(cd $(dirname $0); pwd)
+BASE_DIR=$(cd "$(dirname "$0")" && pwd)
 PREFIX="$1"
 
 FONT_PATTERN=${PREFIX}'HackGen[^3]*.ttf'

--- a/copyright.sh
+++ b/copyright.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-BASE_DIR="$(cd $(dirname $0); pwd)"
+BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 PREFIX="$1"
 

--- a/copyright.sh
+++ b/copyright.sh
@@ -21,8 +21,8 @@ Copyright (c) 2019, Yuko OTAWARA'
 for P in ${BASE_DIR}/${FONT_PATTERN}
 do
   ttx -t name "$P"
-  mv "${P%%.ttf}.ttx" ${BASE_DIR}/tmp.ttx
-  cat ${BASE_DIR}/tmp.ttx | perl -pe "s?###COPYRIGHT###?$COPYRIGHT?" > "${P%%.ttf}.ttx"
+  mv "${P%%.ttf}.ttx" "${BASE_DIR}/tmp.ttx"
+  perl -pe "s?###COPYRIGHT###?$COPYRIGHT?" < "${BASE_DIR}/tmp.ttx" > "${P%%.ttf}.ttx"
 
   mv "$P" "${P}_orig"
   ttx -m "${P}_orig" "${P%%.ttf}.ttx"

--- a/copyright.sh
+++ b/copyright.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 BASE_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 PREFIX="$1"

--- a/hackgen_generator.sh
+++ b/hackgen_generator.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-base_dir=$(cd $(dirname $0); pwd)
+base_dir=$(cd "$(dirname "$0")" && pwd)
 # HackGen Generator
 hackgen_version="$2"
 

--- a/hackgen_generator.sh
+++ b/hackgen_generator.sh
@@ -29,7 +29,6 @@ hackgen35_descent=243
 
 em_ascent=881
 em_descent=143
-em=$(($em_ascent + $em_descent))
 
 typo_line_gap=80
 
@@ -46,7 +45,6 @@ hackgen35_full_width=$((${hackgen35_half_width} * 5 / 3))
 
 # Set path to fontforge command
 fontforge_command="fontforge"
-ttfautohint_command="ttfautohint"
 
 # Set redirection of stderr
 redirection_stderr="/dev/null"
@@ -54,16 +52,8 @@ redirection_stderr="/dev/null"
 # Set fonts directories used in auto flag
 fonts_directories="${base_dir}/source/"
 
-# Set zenkaku space glyph
-zenkaku_space_glyph=""
-
 # Set flags
 leaving_tmp_flag="false"
-fullwidth_ambiguous_flag="true"
-scaling_down_flag="true"
-
-# Set non-Discorded characters
-non_discorded_characters=""
 
 # Set filenames
 hack_regular_src="Hack-Regular.ttf"

--- a/hackgen_generator.sh
+++ b/hackgen_generator.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -e
+
 base_dir=$(cd "$(dirname "$0")" && pwd)
 # HackGen Generator
 hackgen_version="$2"

--- a/hackgen_generator.sh
+++ b/hackgen_generator.sh
@@ -160,12 +160,12 @@ input_hack_bold=`find $fonts_directories -follow -name "$hack_bold_src" | head -
 input_mod_arrow_regular=`find $fonts_directories -follow -name "$mod_arrow_regular_src" | head -n 1`
 input_mod_arrow_bold=`find $fonts_directories -follow -name "$mod_arrow_bold_src" | head -n 1`
 
-if [ -z "${input_hack_regular}" -o -z "${input_hack_bold}" ]
+if [ -z "${input_hack_regular}" ] || [ -z "${input_hack_bold}" ]
 then
   echo "Error: $hack_regular_src and/or $hack_bold_src not found" >&2
   exit 1
 fi
-if [ -z "${input_mod_arrow_regular}" -o -z "${input_mod_arrow_bold}" ]
+if [ -z "${input_mod_arrow_regular}" ] || [ -z "${input_mod_arrow_bold}" ]
 then
   echo "Error: $input_mod_arrow_regular and/or $input_mod_arrow_bold not found" >&2
   exit 1
@@ -174,7 +174,7 @@ fi
 # Search GenJyuuGothicL
 input_genjyuu_regular=`find $fonts_directories -follow -iname "$genjyuu_regular_src" | head -n 1`
 input_genjyuu_bold=`find $fonts_directories -follow -iname "$genjyuu_bold_src"    | head -n 1`
-if [ -z "${input_genjyuu_regular}" -o -z "${input_genjyuu_bold}" ]
+if [ -z "${input_genjyuu_regular}" ] || [ -z "${input_genjyuu_bold}" ]
 then
   echo "Error: $genjyuu_regular_src and/or $genjyuu_bold_src not found" >&2
   exit 1
@@ -215,7 +215,7 @@ then
 fi
 
 # Make temporary directory
-if [ -w "/tmp" -a "${leaving_tmp_flag}" = "false" ]
+if [ -w "/tmp" ] && [ "${leaving_tmp_flag}" = "false" ]
 then
   tmpdir=`mktemp -d /tmp/hackgen_generator_tmpdir.XXXXXX` || exit 2
 else

--- a/hackgen_generator.sh
+++ b/hackgen_generator.sh
@@ -2615,7 +2615,7 @@ do
 
   cdAutoMakeDir() {
     mkdir -p "$1"
-    cd "$1"
+    cd "$1" || exit 1
   }
 
   # HackGen
@@ -2666,7 +2666,7 @@ do
     pyftmerge merged.ttf "$marge_genjyuu_console_regular"
     mv merged.ttf "${base_dir}/${hackgen_nerd_console_filename}"
     
-    cd "${base_dir}"
+    cd "${base_dir}" || exit 1
     ttx -t name "${hackgen_nerd_console_filename}"
     sed -i -e 's/HackGen Console/HackGen Console NF/g; s/HackGenConsole/HackGenConsoleNF/g' "${hackgen_nerd_console_filename%%.ttf}.ttx"
     mv "${hackgen_nerd_console_filename}" "${hackgen_nerd_console_filename}_orig"
@@ -2683,7 +2683,7 @@ do
     pyftmerge merged.ttf "$marge_genjyuu35_console_regular"
     mv merged.ttf "${base_dir}/${hackgen35_nerd_console_filename}"
     
-    cd "${base_dir}"
+    cd "${base_dir}" || exit 1
     ttx -t name "${hackgen35_nerd_console_filename}"
     sed -i -e 's/HackGen35 Console/HackGen35 Console NF/g; s/HackGen35Console/HackGen35ConsoleNF/g' "${hackgen35_nerd_console_filename%%.ttf}.ttx"
     mv "${hackgen35_nerd_console_filename}" "${hackgen35_nerd_console_filename}_orig"

--- a/make_hackgen.sh
+++ b/make_hackgen.sh
@@ -2,7 +2,7 @@
 
 hackgen_version="2.10.0"
 
-BASE_DIR=$(cd $(dirname $0); pwd)
+BASE_DIR=$(cd "$(dirname "$0")" && pwd)
 PREFIX="$1"
 
 function mvBuild() {

--- a/make_hackgen.sh
+++ b/make_hackgen.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 hackgen_version="2.10.0"
 
 BASE_DIR=$(cd "$(dirname "$0")" && pwd)

--- a/os2_patch.sh
+++ b/os2_patch.sh
@@ -16,13 +16,13 @@ for P in ${BASE_DIR}/${HACKGEN_PATTERN}; do
   sed -i.bak -e 's,xAvgCharWidth value="'$xAvgCharWidth_value'",xAvgCharWidth value="'${xAvgCharWidth_SETVAL}'",' "${P%%.ttf}.ttx"
 
   fsSelection_value=$(grep fsSelection "${P%%.ttf}.ttx" | awk -F\" '{print $2}')
-  if [ `echo $P | grep Regular` ]; then
+  if echo "$P" | grep -q Regular; then
     fsSelection_sed_value='00000000 01000000'
-  elif [ `echo $P | grep BoldOblique` ]; then
+  elif echo "$P" | grep -q BoldOblique; then
     fsSelection_sed_value='00000000 00100001'
-  elif [ `echo $P | grep Bold` ]; then
+  elif echo "$P" | grep -q Bold; then
     fsSelection_sed_value='00000000 00100000'
-  elif [ `echo $P | grep Oblique` ]; then
+  elif echo "$P" | grep -q Oblique; then
     fsSelection_sed_value='00000000 00000001'
   fi
   sed -i.bak -e 's,fsSelection value="'"$fsSelection_value"'",fsSelection value="'"$fsSelection_sed_value"'",' "${P%%.ttf}.ttx"
@@ -33,9 +33,8 @@ for P in ${BASE_DIR}/${HACKGEN_PATTERN}; do
   sed -i.bak -e 's,<isFixedPitch value="0"/>,<isFixedPitch value="1"/>,' "${P%%.ttf}.ttx"
 
   mv "$P" "${P}_orig"
-  ttx -m "${P}_orig" "${P%%.ttf}.ttx"
-  
-  if [ $? -eq 0 ]; then
+
+  if ttx -m "${P}_orig" "${P%%.ttf}.ttx"; then
     mv "${P}_orig" "${BASE_DIR}/bak/"
     mv "${P%%.ttf}.ttx" "${BASE_DIR}/bak/"
     rm "${P%%.ttf}.ttx.bak"
@@ -49,13 +48,13 @@ for P in ${BASE_DIR}/${HACKGEN53_PATTERN}; do
   sed -i.bak -e 's,xAvgCharWidth value="'$xAvgCharWidth_value'",xAvgCharWidth value="'${xAvgCharWidth53_SETVAL}'",' "${P%%.ttf}.ttx"
 
   fsSelection_value=$(grep fsSelection "${P%%.ttf}.ttx" | awk -F\" '{print $2}')
-  if [ `echo $P | grep Regular` ]; then
+  if echo "$P" | grep -q Regular; then
     fsSelection_sed_value='00000000 01000000'
-  elif [ `echo $P | grep BoldOblique` ]; then
+  elif echo "$P" | grep -q BoldOblique; then
     fsSelection_sed_value='00000000 00100001'
-  elif [ `echo $P | grep Bold` ]; then
+  elif echo "$P" | grep -q Bold; then
     fsSelection_sed_value='00000000 00100000'
-  elif [ `echo $P | grep Oblique` ]; then
+  elif echo "$P" | grep -q Oblique; then
     fsSelection_sed_value='00000000 00000001'
   fi
   sed -i.bak -e 's,fsSelection value="'"$fsSelection_value"'",fsSelection value="'"$fsSelection_sed_value"'",' "${P%%.ttf}.ttx"
@@ -64,9 +63,8 @@ for P in ${BASE_DIR}/${HACKGEN53_PATTERN}; do
   sed -i.bak -e 's,underlinePosition value="'$underlinePosition_value'",underlinePosition value="-70",' "${P%%.ttf}.ttx"
 
   mv "$P" "${P}_orig"
-  ttx -m "${P}_orig" "${P%%.ttf}.ttx"
-  
-  if [ $? -eq 0 ]; then
+
+  if ttx -m "${P}_orig" "${P%%.ttf}.ttx"; then
     mv -f "${P}_orig" "${BASE_DIR}/bak/"
     mv -f "${P%%.ttf}.ttx" "${BASE_DIR}/bak/"
     rm -f "${P%%.ttf}.ttx.bak"

--- a/os2_patch.sh
+++ b/os2_patch.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-BASE_DIR=$(cd $(dirname $0); pwd)
+BASE_DIR=$(cd "$(dirname "$0")" && pwd)
 PREFIX="$1"
 
 xAvgCharWidth_SETVAL=540

--- a/os2_patch.sh
+++ b/os2_patch.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 BASE_DIR=$(cd "$(dirname "$0")" && pwd)
 PREFIX="$1"
 


### PR DESCRIPTION
Hello,

This lints some parts of scripts with ShellCheck (especially use `grep -E` instead of `egrep`), and set `-e` flag to them.  It could be useful for packaging, in terms of portability and ease of checking validity.


Thank you,